### PR TITLE
Update README for the Open Pathology

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ isyntax2raw .whl file - https://github.com/glencoesoftware/isyntax2raw/releases
 
 raw2ometiff .zip file - https://github.com/glencoesoftware/raw2ometiff/releases
 
-PhilipsSDK - https://www.openpathology.philips.com/
+PhilipsSDK - https://www.openpathology.philips.com/ **(CURRENTLY NOT WORKING - contact Philips)**
 
 Building the docker
 ===================


### PR DESCRIPTION
Updated README as the URL for the SDK doesn't currently work.